### PR TITLE
This commit introduces the initial main menu for the game.

### DIFF
--- a/MainMenu.gd
+++ b/MainMenu.gd
@@ -1,0 +1,9 @@
+extends Control
+
+func _on_start_button_pressed():
+	print("Start button pressed")
+	# get_tree().change_scene_to_file("res://game.tscn") # This will be used later
+
+
+func _on_quit_button_pressed():
+	get_tree().quit()

--- a/MainMenu.tscn
+++ b/MainMenu.tscn
@@ -1,0 +1,46 @@
+[gd_scene load_steps=2 format=3 uid="uid://cyex58n13i26x"]
+
+[ext_resource type="Script" path="res://MainMenu.gd" id="1_f8j1w"]
+
+[node name="MainMenu" type="Control"]
+script = ExtResource("1_f8j1w")
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="ColorRect" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.101961, 0.101961, 0.121569, 1)
+
+[node name="VBoxContainer" type="VBoxContainer" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -50.0
+offset_top = -20.0
+offset_right = 50.0
+offset_bottom = 20.0
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="StartButton" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+text = "Start"
+
+[node name="QuitButton" type="Button" parent="VBoxContainer"]
+layout_mode = 2
+text = "Quit"
+
+[connection signal="pressed" from="VBoxContainer/StartButton" to="." method="_on_start_button_pressed"]
+[connection signal="pressed" from="VBoxContainer/QuitButton" to="." method="_on_quit_button_pressed"]

--- a/project.godot
+++ b/project.godot
@@ -11,5 +11,6 @@ config_version=5
 [application]
 
 config/name="Shootemup"
+run/main_scene="res://MainMenu.tscn"
 config/features=PackedStringArray("4.5", "Forward Plus")
 config/icon="res://icon.svg"


### PR DESCRIPTION
Key changes include:
- A new `MainMenu.tscn` scene that serves as the main menu.
- A `VBoxContainer` is used to organize menu buttons, making it easy to add more options in the future.
- 'Start' and 'Quit' buttons have been added to the menu.
- A corresponding `MainMenu.gd` script handles the button logic:
  - The 'Quit' button exits the game.
  - The 'Start' button currently prints a message, with its future functionality to load the game scene commented out.
- The `project.godot` file has been updated to set `MainMenu.tscn` as the main scene, so it's the first thing that appears when the game launches.