### PR TITLE
Fix(ShipSelection): Use is_empty() instead of empty()

### DIFF
--- a/ShipSelection.gd
+++ b/ShipSelection.gd
@@ -14,7 +14,7 @@ func _on_confirm_button_pressed():
 		return
 
 	var player_name_input = $UI/VBoxContainer/LineEdit.text
-	if not player_name_input.empty():
+	if not player_name_input.is_empty():
 		PlayerData.player_name = player_name_input
 
 	PlayerData.selected_ship = selected_ship_node.name


### PR DESCRIPTION
The `empty()` method does not exist for the String class in GDScript, which was causing a crash.

This commit replaces the incorrect method call `player_name_input.empty()` with the correct method `player_name_input.is_empty()` to correctly check if the player's name is empty.