### PR TITLE
Fix(Compatibility): Update project for Godot 4 compatibility

### DIFF
--- a/Player.tscn
+++ b/Player.tscn
@@ -2,7 +2,7 @@
 
 [ext_resource type="Script" path="res://Player.gd" id="1_player_script"]
 
-[sub_resource type="ConeMesh" id="Mesh_Player_Pyramid"]
+[sub_resource type="CylinderMesh" id="Mesh_Player_Pyramid"]
 top_radius = 0.0
 bottom_radius = 1.414
 height = 2.0


### PR DESCRIPTION
This commit addresses several issues that arose from migrating the project from Godot 3.x to Godot 4.x, which caused the game to crash after the ship selection screen.

The following changes were made:

1.  **`ShipSelection.gd`**: Replaced the non-existent `empty()` string method with the correct `is_empty()` method to prevent a crash when confirming the player's name.

2.  **`Player.tscn`**: Replaced the obsolete `PyramidMesh` and `ConeMesh` resources with `CylinderMesh`, configured to create a pyramid shape. This resolves the "Cannot get class" error.

3.  **`Explosion.tscn`**:
    *   Removed an invalid comment from a material property that was causing a scene parsing error.
    *   Moved the material assignment from the `QuadMesh` sub-resource to the `material_override` property of the `GPUParticles3D` node, following Godot 4 best practices.