### PR TITLE
Feat: Make camera distance configurable

### DIFF
--- a/Script/PlayerData.gd
+++ b/Script/PlayerData.gd
@@ -3,6 +3,7 @@ extends Node
 var player_name: String = "Player"
 var score: int = 0
 var selected_ship: StringName = &"RedShip"
+var camera_distance: float = 75.0
 
 const GAME_DEPTH: float = -10.0
 const PLAYER_BOUNDS_X: Vector2 = Vector2(-30.0, 30.0)

--- a/Script/camera_3d.gd
+++ b/Script/camera_3d.gd
@@ -5,7 +5,7 @@ func _ready():
 	make_current()
 	
 	# Configurar posição e propriedades
-	position = Vector3(0, 0, 50)
+	position = Vector3(0, 0, PlayerData.camera_distance)
 	fov = 70
 	
 	print("Câmera configurada: ", name)


### PR DESCRIPTION
Adds a `camera_distance` variable to the `PlayerData` autoload singleton. The camera script (`camera_3d.gd`) is updated to use this variable to set its Z position, allowing the camera distance to be easily adjusted from a central configuration file.

This change addresses the user's request to have better control over the ship visualization by making the ships appear smaller. The default distance has been increased from 50 to 75.