### PR TITLE
Fix: Camera distance is now correctly applied

### DIFF
--- a/Scene/Game.tscn
+++ b/Scene/Game.tscn
@@ -30,7 +30,6 @@ transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 
 shadow_enabled = true
 
 [node name="Camera3D" type="Camera3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 50)
 projection = 1
 size = 18.0
 script = ExtResource("4_ivtx6")


### PR DESCRIPTION
Removes the hardcoded transform from the Camera3D node in `Game.tscn`. This transform was overriding the position set in the `camera_3d.gd` script, which prevented the configurable camera distance from being applied.

With this fix, the camera's position is now exclusively controlled by the script, which correctly uses the `camera_distance` variable from `PlayerData`. This resolves the issue where changes to the camera distance were not visible in the game.