### PR TITLE
Fix: Controls camera zoom using the 'size' property

### DIFF
--- a/Scene/Game.tscn
+++ b/Scene/Game.tscn
@@ -30,9 +30,7 @@ transform = Transform3D(1, 0, 0, 0, 0.707107, 0.707107, 0, -0.707107, 0.707107, 
 shadow_enabled = true
 
 [node name="Camera3D" type="Camera3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 50)
 projection = 1
-size = 18.0
 script = ExtResource("4_ivtx6")
 
 [node name="UI" type="Control" parent="."]

--- a/Script/PlayerData.gd
+++ b/Script/PlayerData.gd
@@ -3,6 +3,7 @@ extends Node
 var player_name: String = "Player"
 var score: int = 0
 var selected_ship: StringName = &"RedShip"
+var camera_size: float = 30.0
 
 const GAME_DEPTH: float = -10.0
 const PLAYER_BOUNDS_X: Vector2 = Vector2(-30.0, 30.0)

--- a/Script/camera_3d.gd
+++ b/Script/camera_3d.gd
@@ -6,6 +6,7 @@ func _ready():
 	
 	# Configurar posição e propriedades
 	position = Vector3(0, 0, 50)
+	size = PlayerData.camera_size
 	fov = 70
 	
 	print("Câmera configurada: ", name)


### PR DESCRIPTION
This commit corrects the camera zoom functionality for an orthogonal projection camera. The previous approach of modifying the camera's Z-axis position was incorrect for this projection type.

The fix implements the following changes:
1.  Introduces a `camera_size` variable in `PlayerData.gd` to control the camera's zoom level.
2.  Updates `camera_3d.gd` to use `PlayerData.camera_size` to set the camera's `size` property at runtime.
3.  Removes the hardcoded `size` property from the `Camera3D` node in `Game.tscn` to ensure the script has exclusive control over this value.

This ensures the camera's zoom is correctly applied at the start of the game and can be easily configured, resolving the user's issue.